### PR TITLE
French bug '' instead of ' to get braces

### DIFF
--- a/src/org/rapla/plugin/notification/NotificationResources.xml
+++ b/src/org/rapla/plugin/notification/NotificationResources.xml
@@ -11,7 +11,7 @@
   <entry key="mail_subject">
     <text lang="en">Rapla: Allocation change of [{0}]</text>
     <text lang="de">Rapla: Reservierungsbenachrichtigung [{0}]</text>
-    <text lang="fr">Rapla: Changement d'allocation pour [{0}]</text>
+    <text lang="fr">Rapla: Changement d''allocation pour [{0}]</text>
     <text lang="es">Rapla: Cambio de asignación para [{0}]</text>
     <text lang="nl">Rapla: Reservatie wijziging voor [{0}]</text>
   </entry>


### PR DESCRIPTION
As explain line 29 in file /src/org/rapla/RaplaResources.xml

> Note: Problems with the apostrophe character '
> In format strings, that are strings containing the braces character, e.g. {0}
> you should use '' instead of '. Otherwise the braces are not replaced.
> See French text.
