### PR TITLE
Add mailto to attendee URI (conform to RFC)

### DIFF
--- a/src/main/java/org/rapla/plugin/export2ical/server/Export2iCalConverter.java
+++ b/src/main/java/org/rapla/plugin/export2ical/server/Export2iCalConverter.java
@@ -335,7 +335,7 @@ public class Export2iCalConverter
                     final String resourceName = getResourceName(person, user);
                     if (!isEmpty(resourceName))
                     {
-                        Attendee attendee = new Attendee(new URI(email));
+                        Attendee attendee = new Attendee("MAILTO:" + new URI(email).trim());
                         attendee.getParameters().add(Role.REQ_PARTICIPANT);
                         attendee.getParameters().add(new Cn(resourceName));
                         attendee.getParameters().add(new PartStat(exportAttendeesParticipationStatus));


### PR DESCRIPTION
The ATTENDEE section of an event is specified in RFC 5455 like
` attendee   = "ATTENDEE" attparam ":" cal-address CRLF`
If `cal-address` is an email address it's specified by RFC 2368:
`mailtoURL  =  "mailto:" [ to ] [ headers ]`

Currently this mailto is missing. It's there for ther ORGANIZER but not
for ATTENDEE.