### PR TITLE
Update docker base image to alpine:3.23 as 3.18 does not include openjdk21-jre

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.23
 
 WORKDIR /opt/rapla
 


### PR DESCRIPTION
Fix error openjdk21-jre not included in alpine 3:18